### PR TITLE
Better way to derive PD grid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Missing values in `y` are now checked *after* removing observations without positive weights [#56](https://github.com/mayer79/effectplots/pull/56).
 - Plots now skip missing values on the y-axis, also in the ribbons [#57](https://github.com/mayer79/effectplots/pull/57).
 - Factors with explicit NA level are respected, [#59](https://github.com/mayer79/effectplots/pull/59).
+- Empty factor levels are being dropped, [#60](https://github.com/mayer79/effectplots/pull/60).
 
 ### Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - `update(, collapse_m = m)` will now produce a level "other p" for the p least frequent categories [#52](https://github.com/mayer79/effectplots/pull/52).
 - `update()` has received new default: `collapse_m = 15` (was 30) [#54](https://github.com/mayer79/effectplots/pull/54).
 - Missing values in `y` are now checked *after* removing observations without positive weights [#56](https://github.com/mayer79/effectplots/pull/56).
-- Plots now skip missing values on the y-axis, also in the ribbons [#57](https://github.com/mayer79/effectplots/pull/57).
+- Lines now skip missing values on the y-axis, also in the ribbons [#57](https://github.com/mayer79/effectplots/pull/57).
 - Factors with explicit NA level are respected, [#59](https://github.com/mayer79/effectplots/pull/59).
 - Empty factor levels are being dropped, [#60](https://github.com/mayer79/effectplots/pull/60).
 

--- a/R/crunch.R
+++ b/R/crunch.R
@@ -16,12 +16,6 @@ factor_or_double <- function(x, m = 5L, ix_sub = NULL) {
     }
     return(collapse::qF(x, sort = FALSE, na.exclude = FALSE))
   }
-  if (is.double(x)) {
-    # {collapse} seems to distinguish positive and negative zeros
-    # https://github.com/SebKrantz/collapse/issues/648
-    # Adding 0 to a double turns negative 0 to positive ones (ISO/IEC 60559)
-    collapse::setop(x, "+", 0.0)
-  }
   if (!is.null(ix_sub)) {  # we have >10k values
     if (m >= length(ix_sub)) {
       stop("Too large value for m")

--- a/R/crunch.R
+++ b/R/crunch.R
@@ -3,12 +3,16 @@ qF2 <- function(x) {
     # Safe way to keep attributes for PDP while ensuring correct order
     bin_mid <- sort(collapse::funique(x), na.last = TRUE)
     g <- collapse::qF(
-      x, ordered = is.ordered(x), sort = TRUE, na.exclude = !anyNA(unclass(x))
+      x,
+      ordered = is.ordered(x),
+      sort = TRUE,
+      na.exclude = !anyNA(unclass(x)),
+      drop = TRUE
     )
     return(list(g = g, bin_mid = bin_mid))
   }
-  g <- qG(x, sort = FALSE, na.exclude = FALSE, return.groups = TRUE)
-  return(list(g = as_factor_qG(g), bin_mid = attr(g, "groups")))
+  g <- collapse::qG(x, sort = FALSE, na.exclude = FALSE, return.groups = TRUE)
+  return(list(g = collapse::as_factor_qG(g), bin_mid = attr(g, "groups")))
 }
 
 #' Turn Input either Double or Factor
@@ -28,7 +32,7 @@ factor_or_double <- function(x, m = 5L, ix_sub = NULL) {
   if (!is.numeric(x)) {
     qF2(x)
   }
-  if (!is.null(ix_sub)) {  # we have >10k values
+  if (!is.null(ix_sub)) { # we have >10k values
     if (m >= length(ix_sub)) {
       stop("Too large value for m")
     }
@@ -175,7 +179,7 @@ fcut <- function(x, breaks, labels = NULL, right = TRUE, explicit_na = FALSE) {
   )
   codes_only <- isFALSE(labels)
   if (!is.character(labels)) {
-    labels <- as.character(seq_len(nb))  # need for equi-length case even if codes_only
+    labels <- as.character(seq_len(nb)) # need for equi-length case even if codes_only
   }
 
   # From hist2.default()
@@ -195,7 +199,7 @@ fcut <- function(x, breaks, labels = NULL, right = TRUE, explicit_na = FALSE) {
         out[is.na(x)] <- NA_integer_
       }
     }
-  } else if (diff(range(h)) < 1e-07 * mean(h)) {  # spatstat.utils::fastFindInterval()
+  } else if (diff(range(h)) < 1e-07 * mean(h)) { # spatstat.utils::fastFindInterval()
     return(
       findInterval_equi(
         as.double(x),
@@ -210,7 +214,8 @@ fcut <- function(x, breaks, labels = NULL, right = TRUE, explicit_na = FALSE) {
     )
   } else {
     out <- findInterval(
-      x, vec = breaks, rightmost.closed = TRUE, left.open = right, all.inside = TRUE
+      x,
+      vec = breaks, rightmost.closed = TRUE, left.open = right, all.inside = TRUE
     )
     if (explicit_na && anyNA(x)) {
       out[is.na(x)] <- nb + 1L
@@ -222,4 +227,3 @@ fcut <- function(x, breaks, labels = NULL, right = TRUE, explicit_na = FALSE) {
   }
   structure(out, levels = labels, class = c("factor", if (explicit_na) "na.included"))
 }
-

--- a/R/crunch.R
+++ b/R/crunch.R
@@ -30,7 +30,7 @@ qF2 <- function(x) {
 #'   points for partial dependence.
 factor_or_double <- function(x, m = 5L, ix_sub = NULL) {
   if (!is.numeric(x)) {
-    qF2(x)
+    return(qF2(x))
   }
   if (!is.null(ix_sub)) { # we have >10k values
     if (m >= length(ix_sub)) {

--- a/R/crunch.R
+++ b/R/crunch.R
@@ -1,3 +1,27 @@
+#' Prepares discrete feature for grouped operations of {collapse}
+#'
+#' @description
+#' This function returns two elements:
+#' 1. A factor `g` in the same order as `x` used for grouped calculations and
+#' 2. a vector/factor `bin_mid` of unique values of `x` used for partial dependence.
+#'
+#' Comments on `g`:
+#' - The order of values in `g` correspond to the order in `x`.
+#' - Missing values in `x` are represented as an explicit NA level in `g`. This helps
+#'   to avoid unnecessary copies of `g` in subsequent grouped calculations.
+#' - There are not empty levels.
+#'
+#' Comments on `bin_mid`:
+#' - The order of values in `bin_mid` is the same as the levels of `g`.
+#' - It will retain the original class.
+#' - If `x` is a factor, so will be `bin_mid`. It will keep the original levels.
+#' @noRd
+#' @keywords internal
+#'
+#' @param x A discrete vector or factor.
+#' @returns A list with two elements: "g" is a factor representing `x`, while the
+#'  second element "bin_mid" represent corresponding evaluation points for partial
+#'  dependence.
 qF2 <- function(x) {
   if (is.factor(x)) {
     # Safe way to keep attributes for PDP while ensuring correct order
@@ -12,6 +36,9 @@ qF2 <- function(x) {
     return(list(g = g, bin_mid = bin_mid))
   }
   g <- collapse::qG(x, sort = FALSE, na.exclude = FALSE, return.groups = TRUE)
+  # The following lines could be a solution to keep attributes other than class
+  # bin_mid <- attr(g, "groups")
+  # attributes(bin_mid) <- attributes(x)
   return(list(g = collapse::as_factor_qG(g), bin_mid = attr(g, "groups")))
 }
 

--- a/R/feature_effects.R
+++ b/R/feature_effects.R
@@ -116,7 +116,9 @@
 #' xvars <- colnames(iris)[2:5]
 #' M <- feature_effects(fit, v = xvars, data = iris, y = "Sepal.Length", breaks = 5)
 #' M
-#' M |> update(sort = "pd") |> plot(share_y = "all")
+#' M |>
+#'   update(sort = "pd") |>
+#'   plot(share_y = "all")
 feature_effects <- function(object, ...) {
   UseMethod("feature_effects")
 }
@@ -142,8 +144,7 @@ feature_effects.default <- function(
     ale_n = 50000L,
     ale_bin_size = 200L,
     seed = NULL,
-    ...
-) {
+    ...) {
   # Input checks
   stopifnot(
     is.data.frame(data) || is.matrix(data),
@@ -229,7 +230,8 @@ feature_effects.default <- function(
   # Prepare pred (part 2)
   if (is.null(pred) && isTRUE(calc_pred)) {
     pred <- prep_pred(
-      pred_fun(object, data, ...), trafo = trafo, which_pred = which_pred
+      pred_fun(object, data, ...),
+      trafo = trafo, which_pred = which_pred
     )
   }
 
@@ -303,7 +305,7 @@ feature_effects.default <- function(
   )
 
   # Remove empty results (happens if feature is discrete and only ALE was calculated)
-  ok <- lengths(out) > 0L  # non-null (has some columns)
+  ok <- lengths(out) > 0L # non-null (has some columns)
   if (!all(ok)) {
     if (!any(ok)) {
       stop("Nothing has been calculated!")
@@ -336,8 +338,7 @@ feature_effects.ranger <- function(
     pd_n = 500L,
     ale_n = 50000L,
     ale_bin_size = 200L,
-    ...
-) {
+    ...) {
   if (is.null(pred_fun)) {
     pred_fun <- function(model, newdata, ...) {
       stats::predict(model, newdata, ...)$predictions
@@ -368,25 +369,24 @@ feature_effects.ranger <- function(
 #' @describeIn feature_effects Method for DALEX explainer.
 #' @export
 feature_effects.explainer <- function(
-  object,
-  v = colnames(data),
-  data = object$data,
-  y = object$y,
-  pred = NULL,
-  pred_fun = object$predict_function,
-  trafo = NULL,
-  which_pred = NULL,
-  w = object$weights,
-  breaks = "Sturges",
-  right = TRUE,
-  discrete_m = 13L,
-  outlier_iqr = 2,
-  calc_pred = TRUE,
-  pd_n = 500L,
-  ale_n = 50000L,
-  ale_bin_size = 200L,
-  ...
-) {
+    object,
+    v = colnames(data),
+    data = object$data,
+    y = object$y,
+    pred = NULL,
+    pred_fun = object$predict_function,
+    trafo = NULL,
+    which_pred = NULL,
+    w = object$weights,
+    breaks = "Sturges",
+    right = TRUE,
+    discrete_m = 13L,
+    outlier_iqr = 2,
+    calc_pred = TRUE,
+    pd_n = 500L,
+    ale_n = 50000L,
+    ale_bin_size = 200L,
+    ...) {
   feature_effects.default(
     object,
     v = v,
@@ -415,7 +415,7 @@ feature_effects.H2OModel <- function(
     object,
     data,
     v = object@parameters$x,
-    y = NULL,                   #  object@parameters$y does not work for multi-outputs
+    y = NULL, #  object@parameters$y does not work for multi-outputs
     pred = NULL,
     pred_fun = NULL,
     trafo = NULL,
@@ -429,8 +429,7 @@ feature_effects.H2OModel <- function(
     pd_n = 500L,
     ale_n = 50000L,
     ale_bin_size = 200L,
-    ...
-) {
+    ...) {
   if (!requireNamespace("h2o", quietly = TRUE)) {
     stop("Package 'h2o' not installed")
   }
@@ -438,7 +437,8 @@ feature_effects.H2OModel <- function(
   if (inherits(data, "H2OFrame")) {
     if (is.null(pred) && calc_pred) {
       pred <- prep_pred(
-        stats::predict(object, data, ...), trafo = trafo, which_pred = which_pred
+        stats::predict(object, data, ...),
+        trafo = trafo, which_pred = which_pred
       )
     }
     data <- as.data.frame(data)
@@ -507,8 +507,7 @@ calculate_stats <- function(
     ale_data,
     ale_bin_size,
     ix_sub,
-    ...
-) {
+    ...) {
   if (is.double(x)) {
     # {collapse} seems to distinguish positive and negative zeros
     # https://github.com/SebKrantz/collapse/issues/648
@@ -516,6 +515,7 @@ calculate_stats <- function(
     collapse::setop(x, "+", 0.0)
   }
 
+  # For continuous x, we get x. Otherwise, a list including bin_mid as grid
   g <- factor_or_double(x, m = discrete_m, ix_sub = ix_sub)
   discrete <- is.list(g)
 
@@ -523,7 +523,7 @@ calculate_stats <- function(
     return(NULL)
   }
 
-  sd_cols <- setdiff(colnames(PYR), "pred")  # Can be NULL
+  sd_cols <- setdiff(colnames(PYR), "pred") # Can be NULL
 
   # DISCRETE
   if (discrete) {
@@ -554,7 +554,7 @@ calculate_stats <- function(
     # Calculate bin_means, clip outliers, and replace missings (where possible)
     bin_means <- collapse::fmean(x, g = ix, w = w, use.g.names = FALSE)
     bad <- is.na(bin_means)
-    bin_means[bad] = mids[bad]
+    bin_means[bad] <- mids[bad]
     bin_means <- pmax(pmin(bin_means, breaks[length(breaks)]), breaks[1L])
 
     out <- data.frame(bin_mid = mids, bin_width = bin_width, bin_mean = bin_means, M)
@@ -586,7 +586,7 @@ calculate_stats <- function(
         v = v,
         data = ale_data$X,
         breaks = breaks,
-        right = right,  # does not matter because we pass g
+        right = right, # does not matter because we pass g
         pred_fun = pred_fun,
         trafo = trafo,
         which_pred = which_pred,
@@ -601,7 +601,7 @@ calculate_stats <- function(
       cvars <- intersect(c("pd", "pred_mean", "y_mean"), colnames(out))
       if (length(cvars)) {
         w_ok <- out$weight[ok]
-        ale_mids <- 0.5 * (ale + c(0, ale[-length(ale)]))  # average ALE per bin
+        ale_mids <- 0.5 * (ale + c(0, ale[-length(ale)])) # average ALE per bin
         ale <- ale + collapse::fmean(out[[cvars[1L]]][ok], na.rm = TRUE, w = w_ok) -
           collapse::fmean(ale_mids, w = w_ok)
       }

--- a/R/feature_effects.R
+++ b/R/feature_effects.R
@@ -509,6 +509,12 @@ calculate_stats <- function(
     ix_sub,
     ...
 ) {
+  if (is.double(x)) {
+    # {collapse} seems to distinguish positive and negative zeros
+    # https://github.com/SebKrantz/collapse/issues/648
+    # Adding 0 to a double turns negative 0 to positive ones (ISO/IEC 60559)
+    collapse::setop(x, "+", 0.0)
+  }
   # "factor", "double", "integer", "logical", "character"
   orig_type <- if (is.factor(x)) "factor" else typeof(x)
   was_ordered <- is.ordered(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,41 +43,6 @@ is_discrete <- function(x) {
   return(intersect(statistics, colnames(x)))
 }
 
-#' Converts Rownames to Original Type
-#'
-#' Internal function used in `calculate_stats()` to turn rownames `x` of a grouped
-#' aggregation data back to the original `type`. For doubles, we can lose precision,
-#' but this should not a problem here.
-#'
-#' @noRd
-#' @keywords internal
-#'
-#' @param x A character vector of row names, may contain `NA`.
-#' @param type One of "factor", "double", "integer", "logical", and "character".
-#' @param ord Is the factor ordered? By default `FALSE`. Only relevant for factors.
-#' @param lev If type = "factor", its original levels.
-#' @returns
-#'   A data.frame with variables not in `to_stack`, a column "varying_" with
-#'   the column name from `to_stack`, and finally a column "value_" with stacked values.
-parse_rownames <- function(x, type, ord = FALSE, lev = NULL) {
-  if (!is.character(x)) {
-    stop("Row names must be strings")
-  }
-  if (type == "factor" && is.null(lev)) {
-    stop("Need 'lev' for type = 'factor'.")
-  }
-  switch(
-    type,
-    factor = factor(
-      x, levels = lev, ordered = ord, exclude = if (anyNA(lev)) NULL else NA
-    ),
-    double = as.double(x),
-    integer = as.integer(x),
-    logical = as.logical(x),
-    character = x,
-    stop("Can only handle features of type factor, double, integer, logical, and character.")
-  )
-}
 
 # -> plot()
 

--- a/backlog.R
+++ b/backlog.R
@@ -28,6 +28,7 @@ bench::mark(
 # 0.7s      593 MB  # rnorm
 # 0.4s      504 MB  # sample(c(0, 1))
 # 0.2s      502 MB  # sample(0:1)
+# 0.2s      528 MB  # sample(letters[1:4])
 # 0.2s      139 MB  # factor(letters[1:4])
 
 # Matrix
@@ -47,40 +48,39 @@ bench::mark(
 # 0.9s    1.27GB
 
 x <- runif(n)
-bench::mark(frange(x))  # 8 ms
+bench::mark(frange(x)) # 8 ms
 
 # Discrete double -> sort = TRUE!   potential: 85% / 200ms
 x <- sample(c(pi, exp(1), exp(-1)), n, TRUE)
 x <- sample(c(0, 1, 2), n, TRUE)
-bench::mark(qF(x))                # 417/204 ms
-bench::mark(qF(x, sort=F))        # 21 ms
-bench::mark(funique(x))           # 22 ms
-bench::mark(fnunique(x))          # 19 ms
+bench::mark(qF(x)) # 417/204 ms
+bench::mark(qF(x, sort = F)) # 21 ms
+bench::mark(funique(x)) # 22 ms
+bench::mark(fnunique(x)) # 19 ms
 
 # Int (sort = TRUE)               potential 50% / 19ms
 x <- sample(1:10, n, TRUE)
-bench::mark(qF(x))                # 24 ms
-bench::mark(qF(x, sort = FALSE))  # 11 ms
-bench::mark(funique(x))           # 6 ms
-bench::mark(fnunique(x))          # 8 ms
+bench::mark(qF(x)) # 24 ms
+bench::mark(qF(x, sort = FALSE)) # 11 ms
+bench::mark(funique(x)) # 6 ms
+bench::mark(fnunique(x)) # 8 ms
 
 # Logical (sort does not matter)  potential 30% / 5ms
 x <- sample(c(TRUE, FALSE), n, TRUE)
-bench::mark(qF(x))                # 8 ms
-bench::mark(qF(x, sort = FALSE))  # 8 ms
-bench::mark(funique(x))           # 5 ms
+bench::mark(qF(x)) # 8 ms
+bench::mark(qF(x, sort = FALSE)) # 8 ms
+bench::mark(funique(x)) # 5 ms
 
 # Char -> sort = FALSE  . potential: 65% / 21ms
 x <- sample(letters[1:10], n, TRUE)
-bench::mark(qF(x))                # 26 ms
-bench::mark(qF(x, sort = FALSE))  # 12 ms
-bench::mark(funique(x))           # 7 ms
+bench::mark(qF(x)) # 26 ms
+bench::mark(qF(x, sort = FALSE)) # 12 ms
+bench::mark(funique(x)) # 7 ms
+
+bench::mark(qF(x, sort = FALSE, na.exclude = FALSE))
 
 # Factor -> sort = TRUE : potential: 100% / 5ms
 x <- factor(sample(letters[1:10], n, TRUE))
-bench::mark(qF(x))                # 0 ms
-bench::mark(qF(x, sort = FALSE))  # 7 ms
-bench::mark(funique(x))           # 5 ms
-
-
-
+bench::mark(qF(x)) # 0 ms
+bench::mark(qF(x, sort = FALSE)) # 7 ms
+bench::mark(funique(x)) # 5 ms

--- a/backlog.R
+++ b/backlog.R
@@ -48,7 +48,6 @@ bench::mark(
 
 x <- runif(n)
 bench::mark(frange(x))  # 8 ms
-bench::mark(effectplots:::clamp2(x, 0.1, 0.9))  # 16 ms
 
 # Discrete double -> sort = TRUE!   potential: 85% / 200ms
 x <- sample(c(pi, exp(1), exp(-1)), n, TRUE)
@@ -82,3 +81,6 @@ x <- factor(sample(letters[1:10], n, TRUE))
 bench::mark(qF(x))                # 0 ms
 bench::mark(qF(x, sort = FALSE))  # 7 ms
 bench::mark(funique(x))           # 5 ms
+
+
+

--- a/man/feature_effects.Rd
+++ b/man/feature_effects.Rd
@@ -238,7 +238,9 @@ fit <- lm(Sepal.Length ~ ., data = iris)
 xvars <- colnames(iris)[2:5]
 M <- feature_effects(fit, v = xvars, data = iris, y = "Sepal.Length", breaks = 5)
 M
-M |> update(sort = "pd") |> plot(share_y = "all")
+M |>
+  update(sort = "pd") |>
+  plot(share_y = "all")
 }
 \references{
 \enumerate{

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -99,21 +99,16 @@ test_that("update() can sort according to importance", {
   expect_error(effect_importance(M, by = "something"))
 })
 
-test_that("update() can drop empty levels", {
+test_that("update() can drop empty levels of continuous features", {
   M2 <- feature_effects(
     fit,
-    v = c("Petal.Length", "Petal.Width", "Species"),
-    data = iris[51:150, ],
+    v = c("Petal.Length"),
+    data = iris,
     y = "Sepal.Length",
     w = "Sepal.Width",
-    breaks = 5
+    breaks = 10
   )
 
-  # setosa is here and stays with a normal update
-  expect_equal(M2$Species[1L, "N"], 0)
-  expect_equal(update(M2, drop_empty = FALSE)$Species[1L, "N"], 0)
-
-  # Not anymore
-  expect_false("setosa" %in% levels(update(M2, drop_empty = TRUE)$Species$bin_mid))
+  expect_true(any(M2$Petal.Length$N == 0))
+  expect_true(!any(update(M2, drop_empty = TRUE)$Petal.Length$N == 0))
 })
-

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,30 +1,3 @@
-test_that("parse_rownames() does what it should", {
-  x <- c("3", "1", NA)
-  lev <- c("3", "1")
-  expect_equal(parse_rownames(x, "character"), x)
-  expect_equal(parse_rownames(x, "integer"), c(3L, 1L, NA))
-  expect_equal(parse_rownames(x, "factor", lev = lev), factor(x, levels = lev))
-  expect_equal(parse_rownames(c("3.11111", "2", NA), "double"), c(3.11111, 2, NA))
-  expect_equal(parse_rownames(c("TRUE", NA), "logical"), c(TRUE, NA))
-
-  xord <- c("A", "B", NA)
-  expect_equal(
-    parse_rownames(xord, "factor", ord = TRUE, lev = c("A", "B")), ordered(xord)
-  )
-
-  # What if the original factor contains explicit NA level?
-  lev <- c("3", "1", NA)
-  expect_equal(
-    parse_rownames(x, "factor", lev = lev),
-    factor(x, levels = lev, exclude = NULL)
-  )
-
-  expect_error(parse_rownames(x, "date"))
-  expect_error(parse_rownames(1:3, "integer"))
-  expect_error(parse_rownames(x, "factor"))
-})
-
-
 test_that("poor_man_stack() works (test could be improved)", {
   y <- c("a", "b", "c")
   z <- c("aa", "bb", "cc")


### PR DESCRIPTION
In the discrete case, the PD grid was derived from the grouped factor levels. Now, we use a much more direct way via `collapse::qG()`, which returns a factor-like object along with the original unique values.